### PR TITLE
Update Android.mk

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -83,7 +83,7 @@ LOCAL_MODULE := sphinxfeat
 LOCAL_SRC_FILES := \
   agc.c \
   cmn.c \
-  cmn_prior.c \
+  cmn_live.c \
   feat.c \
   lda.c
 


### PR DESCRIPTION
The latest version of sphinxbase has no cmn_prior.c but cmn_live.c was added.