### PR TITLE
added android config folder to cmake includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ add_library( pocketsphinx_jni SHARED
 	     ${SPHINXBASE_SOURCES_ABS} ${POCKETSPHINX_SOURCES_ABS}
 )
              
-include_directories(../sphinxbase/include ../sphinxbase/include/sphinxbase ../pocketsphinx/include)
+include_directories(../sphinxbase/include ../sphinxbase/include/android ../sphinxbase/include/sphinxbase ../pocketsphinx/include)
 
 add_definitions(-DHAVE_CONFIG_H)
 


### PR DESCRIPTION
Simple fix to add the android-specific config directory in the Cmake includes.

This fixes everything so that you can follow the build instructions provided on http://cmusphinx.sourceforge.net/wiki/tutorialandroid and it will actually build.